### PR TITLE
Added the section on Swift vs Objective C type choice

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -211,7 +211,7 @@ When programming in Swift, always use Swift's native types when available. If yo
 **Preferred:**
 ```swift
 let width = 120.0                                           //Float
-let widthString = width.bridgeToObjectiveC().stringValue    //Float
+let widthString = width.bridgeToObjectiveC().stringValue    //String
 ```
 
 **Not Preferred:**


### PR DESCRIPTION
I feel that this issue does not need to be debated any further. We cannot stay in the old when there are types optimized for this new language. Continuing to use NSObject subclasses in Swift when alternatives can be used will look out of place.
