### PR TITLE
expose the correct class name to Objective C

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -100,7 +100,7 @@ You **should not** add prefixes to your Swift types.
 If you need to expose a Swift type for use within Objective-C you can provide a suitable prefix (following our [Objective-C style guide](https://github.com/raywenderlich/objective-c-style-guide)) as follows:
 
 ```swift
-@objc (RWTChicken) class Chicken {
+@objc (Chicken) class RWTChicken {
    ...
 }
 ```


### PR DESCRIPTION
In Xcode 6.0.1 it seems we need to put the swift class name in parentheses after the @objc attribute. This appears semantically incorrect, but it exposes the correct class name to objective c in the ModuleName-Swift.h interface file. 
