### PR TITLE
Steal from the Github style guide!

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -142,6 +142,16 @@ Avoid block comments inline with code, as the code should be as self-documenting
 
 ## Classes and Structures
 
+### Which one to use?
+
+Remember, structs have [value semantics](https://developer.apple.com/library/mac/documentation/Swift/Conceptual/Swift_Programming_Language/ClassesAndStructures.html#//apple_ref/doc/uid/TP40014097-CH13-XID_144). Use structs for things that do not have an identity. An array that contains [a, b, c] is really the same as another array that contains [a, b, c] and they are completely interchangeable. It doesn't matter whether you use the first array or the second, because they represent the exact same thing. That's why arrays are structs.
+
+Classes have [reference semantics](https://developer.apple.com/library/mac/documentation/Swift/Conceptual/Swift_Programming_Language/ClassesAndStructures.html#//apple_ref/doc/uid/TP40014097-CH13-XID_145). Use classes for things that do have an identity or a specific life cycle. You would model a person as a class because two person objects are two different things. Just because two people have the same name and birthdate, doesn't mean they are the same person. But the person's birthdate would be a struct because a date of 3 March 1950 is the same as any other date object for 3 March 1950. The date itself doesn't have an identity.
+
+Sometimes, things should be structs but need to conform to `AnyObject` or are historically modeled as classes already (`NSDate`, `NSSet`). Try to follow these guidelines as closely as possible.
+
+### Example definition
+
 Here's an example of a well-styled class definition:
 
 ```swift


### PR DESCRIPTION
GitHub have created their own guide here:

https://github.com/github/swift-style-guide

Good to see that we agree on quite a few syntax related points. However theirs is a lot more opinionated.

I am still trying to get my head around Swift structs and how widely to use them, notice that GitHub advise you to [prefer structs over classes](https://github.com/github/swift-style-guide?utm_content=buffer92806&utm_medium=social&utm_source=twitter.com&utm_campaign=buffer#prefer-structs-over-classes).
