### PR TITLE
new struct inits over old C functions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -309,6 +309,8 @@ let bounds = CGRectMake(40, 20, 120, 80)
 var centerPoint = CGPointMake(96, 42)
 ```
 
+Prefer the struct-scope constants `CGRect.infiniteRect`, `CGRect.nullRect`, etc. over global constants `CGRectInfinite`, `CGRectNull`, etc. For existing variables, you can use the shorter `.zeroRect`.
+
 ### Type Inference
 
 The Swift compiler is able to infer the type of variables and constants. You can provide an explicit type via a type alias (which is indicated by the type after the colon), but in the majority of cases this is not necessary.


### PR DESCRIPTION
I think that all new code (or code that's being updated) should use the new struct initializers.

I personally never liked CGPointMake() and am now glad that I can write CGPoint(x: 10, y: 20) - it is much much much more readable.

So:
- CGPoint(x:, y:) over CGPointMake
- CGSize(width:, height:) over CGSizeMake
- CGRect(x:, y:, width:, height:) over CGRectMake

How does the rest of you feel about that?
If "yes, that's awesome" - anymore examples we need to highlight?

And yeah - I know that Apple might change the underlying structure for CGPoint, but I think we should stop living and fear and assume that a point is gonna be made of an X and a Y in at least our lifetime.
