### PR TITLE
Protocol conformance in extensions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -14,6 +14,7 @@ Writing Objective-C? Check out our [Objective-C Style Guide](https://github.com/
 * [Comments](#comments)
 * [Classes and Structures](#classes-and-structures)
   * [Use of Self](#use-of-self)
+  * [Protocol Conformance](#protocol-conformance)
 * [Function Declarations](#function-declarations)
 * [Closures](#closures)
 * [Types](#types)
@@ -209,6 +210,33 @@ class BoardLocation {
   }
 }
 ```
+
+### Protocol Conformance
+
+When adding protocol conformance to a class, prefer adding a separate class extension for the protocol methods. This keeps the related methods grouped together with the protocol and can simplify instructions to add a protocol to a class with its associated methods.
+
+**Preferred:**
+```swift
+class MyViewcontroller: UIViewController {
+  // class stuff here
+}
+
+extension MyViewcontroller: UITableViewDataSource {
+  // table view data source methods
+}
+
+extension MyViewcontroller: UIScrollViewDelegate {
+  // scroll view delegate methods
+}
+```
+
+**Not Preferred:**
+```swift
+class MyViewcontroller: UIViewController, UITableViewDataSource, UIScrollViewDelegate {
+  // all methods
+}
+```
+
 
 ## Function Declarations
 


### PR DESCRIPTION
This is something Matt G. did in _Swift by Tutorials_ that I liked. When you want to implement a protocol, I propose doing this as a class extension rather than adding it to the `class` declaration.

Rationale: keeps the `class` line clear, groups the protocol + its methods together, and can simply "add this code to the file" instructions by adding protocol conformance + methods in one shot.

See pull request for suggested text. You cannot declare properties in extensions so this is not great if part of implementing the protocol involves some closely related properties. But I think it's still worthwhile.
