### PR TITLE
Adopt Swift 2.0 syntax for external parameter names.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -63,13 +63,13 @@ For functions and init methods, prefer named parameters for all arguments unless
 
 ```swift
 func dateFromString(dateString: String) -> NSDate
-func convertPointAt(#column: Int, #row: Int) -> CGPoint
-func timedAction(#delay: NSTimeInterval, perform action: SKAction) -> SKAction!
+func convertPointAt(column column: Int, row row: Int) -> CGPoint
+func timedAction(afterDelay delay: NSTimeInterval, perform action: SKAction) -> SKAction!
 
 // would be called like this:
 dateFromString("2014-03-14")
 convertPointAt(column: 42, row: 13)
-timedAction(delay: 1.0, perform: someOtherAction)
+timedAction(afterDelay: 1.0, perform: someOtherAction)
 ```
 
 For methods, follow the standard Apple convention of referring to the first parameter in the method name:


### PR DESCRIPTION
It looks like the use of '#' to succinctly specify external parameter names doesn't work any longer in Swift 2. 

The compiler error reads:
```
'#' has been removed from Swift; double up 'column column' to make the argument label the same as the parameter name
```