### PR TITLE
clarifies enum example

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -130,8 +130,8 @@ Following Apple's API Design Guidelines for Swift 3, use lowerCamelCase for enum
 enum Shape {
   case rectangle
   case square
-  case triangle
-  case circle
+  case rightTriangle
+  case equilateralTriangle
 }
 ```
 


### PR DESCRIPTION
Adds examples that demonstrate the stated style guideline for naming enums.