### PR TITLE
Fix errors naming

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -838,8 +838,8 @@ When coding with conditionals, the left hand margin of the code should be the "g
 ```swift
 func computeFFT(context: Context?, inputData: InputData?) throws -> Frequencies {
 
-  guard let context = context else { throw FFTError.NoContext }
-  guard let inputData = inputData else { throw FFTError.NoInputData }
+  guard let context = context else { throw FFTError.noContext }
+  guard let inputData = inputData else { throw FFTError.noInputData }
     
   // use context and input to compute the frequencies
     
@@ -858,11 +858,11 @@ func computeFFT(context: Context?, inputData: InputData?) throws -> Frequencies 
       return frequencies
     }
     else {
-      throw FFTError.NoInputData
+      throw FFTError.noInputData
     }
   }
   else {
-    throw FFTError.NoContext
+    throw FFTError.noContext
   }
 }
 ```


### PR DESCRIPTION
Fix error naming according to [ErrorProtocol doc on Swift master branch](https://github.com/apple/swift/blob/master/stdlib/public/core/ErrorType.swift#L35-L37) 