### PR TITLE
Replaced abbreviation "sel" with "aSelector", no trailing whitespace rule, new line character at the end of file rule, line width rule.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -168,12 +168,12 @@ Selectors are Obj-C methods that act as handlers for many Cocoa and Cocoa Touch 
 
 **Preferred:**
 ```swift
-let aSelector = #selector(viewDidLoad)
+let selector = #selector(viewDidLoad)
 ```
 
 **Not Preferred:**
 ```swift
-let aSelector = #selector(ViewController.viewDidLoad)
+let selector = #selector(ViewController.viewDidLoad)
 ```
 
 ### Generics

--- a/README.markdown
+++ b/README.markdown
@@ -330,6 +330,7 @@ class TestDatabase : Database {
 
 * No trailing whitespaces at the ends of lines.
 * New line character at the end of file.
+* Use maximum 100 characters line width.
 
 ## Comments
 

--- a/README.markdown
+++ b/README.markdown
@@ -168,12 +168,12 @@ Selectors are Obj-C methods that act as handlers for many Cocoa and Cocoa Touch 
 
 **Preferred:**
 ```swift
-let sel = #selector(viewDidLoad)
+let aSelector = #selector(viewDidLoad)
 ```
 
 **Not Preferred:**
 ```swift
-let sel = #selector(ViewController.viewDidLoad)
+let aSelector = #selector(ViewController.viewDidLoad)
 ```
 
 ### Generics

--- a/README.markdown
+++ b/README.markdown
@@ -329,6 +329,7 @@ class TestDatabase : Database {
 ```
 
 * No trailing whitespaces at the ends of lines.
+* New line character at the end of file.
 
 ## Comments
 

--- a/README.markdown
+++ b/README.markdown
@@ -328,6 +328,8 @@ class TestDatabase : Database {
 }
 ```
 
+* No trailing whitespaces at the ends of lines.
+
 ## Comments
 
 When they are needed, use comments to explain **why** a particular piece of code does something. Comments must be kept up-to-date or deleted.


### PR DESCRIPTION
Using "sel" contradicts the coding convention in the same document: "Abbreviations and acronyms should generally be avoided."
"aSelector" is used in https://developer.apple.com/library/mac/documentation/General/Conceptual/DevPedia-CocoaCore/Selector.html .