### PR TITLE
adding a let as required by the Swift 3 compiler

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -602,7 +602,7 @@ var subview: UIView?
 var volume: Double?
 
 // later on...
-if let subview = subview, volume = volume {
+if let subview = subview, let volume = volume {
   // do something with unwrapped subview and volume
 }
 ```


### PR DESCRIPTION
Changed:
`if let subview = subview, volume = volume`
to:
`if let subview = subview, let volume = volume`

The former will not compile in Swift 3.