### PR TITLE
Fix indentation and formatting of trailing closure syntax example

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -453,10 +453,10 @@ UIView.animate(withDuration: 1.0) {
 }
 
 UIView.animate(withDuration: 1.0, animations: {
-    self.myView.alpha = 0
-  }, completion: { finished in
-    self.myView.removeFromSuperview()
-  })
+  self.myView.alpha = 0
+}, completion: { finished in
+  self.myView.removeFromSuperview()
+})
 ```
 
 **Not Preferred:**
@@ -465,11 +465,10 @@ UIView.animate(withDuration: 1.0, animations: {
   self.myView.alpha = 0
 })
 
-UIView.animate(withDuration: 1.0,
-  animations: {
-    self.myView.alpha = 0
-  }) { f in
-    self.myView.removeFromSuperview()
+UIView.animate(withDuration: 1.0, animations: {
+  self.myView.alpha = 0
+}) { f in
+  self.myView.removeFromSuperview()
 }
 ```
 


### PR DESCRIPTION
- Fix indentation to use 2 spaces
- Remove the line break before the “animations” parameter in the “Not Preferred” example so that its formatting is consistent with the code in the “Preferred” example. While this style is still technically not preferred, this section is about whether or not to use trailing closure syntax. This way it is also easier for the reader to see at a glance what the difference is without having to mentally account for the line break.