### PR TITLE
Improve wording of the newline character sentence

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -298,7 +298,7 @@ class TestDatabase : Database {
 
 * Avoid trailing whitespaces at the ends of lines.
 
-* Add a new line character at the end of file.
+* Add a single newline character at the end of each file.
 
 ## Comments
 


### PR DESCRIPTION
- Add the word “single” to make it a bit more clear that there should not be multiple blank lines at the end of a file
- “new line character” -> “newline character”
- “end of file” -> “end of each file”