### PR TITLE
Rectifies the guidelines for the noun methods following the formX rule

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -69,7 +69,7 @@ Descriptive and consistent naming makes software easier to read and understand. 
 - beginning factory methods with `make`
 - naming methods for their side effects
   - verb methods follow the -ed, -ing rule for the non-mutating version
-  - noun methods follow the formX rule for the non-mutating version
+  - noun methods follow the formX rule for the mutating version
   - boolean types should read like assertions
   - protocols that describe _what something is_ should read as nouns
   - protocols that describe _a capability_ should end in _-able_ or _-ible_


### PR DESCRIPTION
The noun methods following the formX rule should be for the mutating version.