### PR TITLE
Note this has been updated for Swift 4

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,5 +1,5 @@
 # The Official raywenderlich.com Swift Style Guide.
-### Updated for Swift 3
+### Updated for Swift 4
 
 This style guide is different from others you may see, because the focus is centered on readability for print and the web. We created this style guide to keep the code in our books, tutorials, and starter kits nice and consistent — even though we have many different authors working on the books.
 


### PR DESCRIPTION
This document has already been updated for Swift 4, but when I first read this first line, I thought, "uh oh, has this not been touched since Swift 3?"

Of course, the last edited date and a quick search for "Swift 4" turned up matches, so I realized we're good.

Maybe there's even a better way to indicate this, such as a table showing what versions of Swift this documentation is geared toward?  But for now, at least mentioning this is updated for Swift 4 seems helpful to someone newly discovering these docs.