### PR TITLE
Update README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -461,7 +461,8 @@ For functions with long signatures, put each parameter on a new line and add an 
 func reticulateSplines(
   spline: [Double], 
   adjustmentFactor: Double,
-  translateConstant: Int, comment: String
+  translateConstant: Int, 
+  comment: String
 ) -> Bool {
   // reticulate code goes here
 }


### PR DESCRIPTION
Update function declarations example so that the each parameter is on its own line.

**FROM**
```swift
func reticulateSplines(
      spline: [Double],
      adjustmentFactor: Double,
      translateConstant: Int, comment: String
) -> Bool {
      // reticulate code goes here
}
```

**TO**
```swift
func reticulateSplines(
    spline: [Double],
    adjustmentFactor: Double,
    translateConstant: Int,
    comment: String
) -> Bool {
        // reticulate code goes here
}
```