### PR TITLE
Update formatting of guard return statement for consistency

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -791,9 +791,7 @@ Extend object lifetime using the `[weak self]` and `guard let self = self else {
 **Preferred**
 ```swift
 resource.request().onComplete { [weak self] response in
-  guard let self = self else {
-    return
-  }
+  guard let self = self else { return }
   let model = self.updateModel(response)
   self.updateUI(model)
 }


### PR DESCRIPTION
Variations of `guard let self = self else { return }` are referenced 3 times in this guide as a single line.

This PR fixes the 4th occurrence to condense the guard return statement to a single line for consistency.