### PR TITLE
Update the year in the copyright notice.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1091,7 +1091,7 @@ The following copyright statement should be included at the top of every source
 file:
 
 ```swift
-/// Copyright (c) 2021 Razeware LLC
+/// Copyright (c) 2022 Razeware LLC
 /// 
 /// Permission is hereby granted, free of charge, to any person obtaining a copy
 /// of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
I assume we update the year every year [?] :] 

I saw an older conversation here: [Update the year in the copyright notice](https://github.com/raywenderlich/swift-style-guide/pull/130/commits/7f298b57e5c319e271e1cf0137459422f72c890f) 